### PR TITLE
Add MacBook notch support, continuous rounded corners, and terminal padding

### DIFF
--- a/Sources/DropCode/main.swift
+++ b/Sources/DropCode/main.swift
@@ -80,6 +80,24 @@ final class PanelClipView: NSView {
         super.init(frame: frameRect)
         wantsLayer = true
         layer?.masksToBounds = true
+        layer?.cornerRadius = 14
+        layer?.cornerCurve = .continuous
+    }
+
+    func updateCornerMask(hasTopInset: Bool, isFullWidth: Bool) {
+        if hasTopInset || !isFullWidth {
+            layer?.maskedCorners = [
+                .layerMinXMinYCorner,
+                .layerMaxXMinYCorner,
+                .layerMinXMaxYCorner,
+                .layerMaxXMaxYCorner,
+            ]
+        } else {
+            layer?.maskedCorners = [
+                .layerMinXMinYCorner,
+                .layerMaxXMinYCorner,
+            ]
+        }
     }
 
     @available(*, unavailable)
@@ -249,6 +267,10 @@ final class DropPanelController: NSObject {
         clipView.autoresizingMask = [.width, .height]
         terminalContainer.autoresizingMask = [.width, .height]
         clipView.addSubview(terminalContainer)
+        clipView.updateCornerMask(
+            hasTopInset: initialScreen.safeAreaInsets.top > 0,
+            isFullWidth: widthRatio >= 1.0
+        )
         panel.contentView = clipView
 
         if notificationsEnabled {
@@ -374,6 +396,10 @@ final class DropPanelController: NSObject {
                 widthRatio: panelWidthRatio
             )
             previousApplication = NSWorkspace.shared.frontmostApplication
+            clipView.updateCornerMask(
+                hasTopInset: screen.safeAreaInsets.top > 0,
+                isFullWidth: panelWidthRatio >= 1.0
+            )
             panel.setFrame(frame, display: false)
             clipView.layoutSubtreeIfNeeded()
             terminalContainer.frame = hiddenContentFrame
@@ -448,6 +474,10 @@ final class DropPanelController: NSObject {
             widthRatio: panelWidthRatio
         )
         panel.setFrame(frame, display: isVisible)
+        clipView.updateCornerMask(
+            hasTopInset: screen.safeAreaInsets.top > 0,
+            isFullWidth: panelWidthRatio >= 1.0
+        )
         clipView.layoutSubtreeIfNeeded()
         terminalContainer.frame = isVisible ? clipView.bounds : hiddenContentFrame
         terminalView?.fitToSize()
@@ -541,11 +571,13 @@ final class DropPanelController: NSObject {
         widthRatio: CGFloat
     ) -> NSRect {
         let screenFrame = screen.frame
-        let height = max(1, floor(screenFrame.height * heightRatio))
+        let topInset = screen.safeAreaInsets.top
+        let usableHeight = max(1, screenFrame.height - topInset)
+        let height = max(1, floor(usableHeight * heightRatio))
         let width = max(1, floor(screenFrame.width * widthRatio))
         return NSRect(
             x: screenFrame.midX - width / 2,
-            y: screenFrame.maxY - height,
+            y: screenFrame.maxY - topInset - height,
             width: width,
             height: height
         )
@@ -554,8 +586,8 @@ final class DropPanelController: NSObject {
     private static var terminalConfiguration: TerminalConfiguration {
         TerminalConfiguration(startingFrom: .default) { builder in
             builder.withFontSize(14)
-            builder.withWindowPaddingX(0)
-            builder.withWindowPaddingY(0)
+            builder.withWindowPaddingX(10)
+            builder.withWindowPaddingY(8)
             builder.withCustom("mouse-hide-while-typing", "true")
             builder.withCustom("scrollbar", "never")
         }


### PR DESCRIPTION
### Summary

This PR improves DropCode's visual presentation and macOS display handling with three focused enhancements:

1. **MacBook Notch Support**:
   - Computes layout using `screen.safeAreaInsets.top` so the drop-down panel positions neatly below camera notches on newer MacBooks instead of clipping behind the notch.
   - **Zero impact on non-notch displays / external monitors**: When `safeAreaInsets.top` is `0`, the positioning and height calculations remain identical to existing behavior (`usableHeight == screenFrame.height`).

2. **Continuous Rounded Corners**:
   - Adds smooth continuous rounded corners (`cornerRadius = 14`, `cornerCurve = .continuous`).
   - Dynamically masks corners: rounds all 4 corners when the panel is floating / inset from the top (or on notch screens); rounds only the bottom corners when attached to the top edge at full width.

3. **Terminal Padding**:
   - Configures default terminal window padding (`paddingX: 10`, `paddingY: 8`) so terminal output and cursor have subtle breathing room from the panel boundaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved panel corner rounding to match its position and width.
  * Adjusted panel placement to respect the screen’s safe-area top inset.
  * Updated terminal window padding for improved spacing.

* **Style**
  * Applied consistent 14-point rounded corners to panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->